### PR TITLE
Add notifyFailed and rbenvRub methods

### DIFF
--- a/vars/notifyFailed.groovy
+++ b/vars/notifyFailed.groovy
@@ -1,0 +1,3 @@
+def call() {
+  slackSend (color: '#FF0000', message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+}

--- a/vars/rbenvRun.groovy
+++ b/vars/rbenvRun.groovy
@@ -1,0 +1,6 @@
+def call(version, command) {
+  sh (
+    script: "#!/bin/bash\nrbenv local ${version}\n${command}",
+    returnStdout: true
+  )
+}


### PR DESCRIPTION
Extract common code to cps libraries.
- notifyFailed - Send slack message when the build fails.
- rbenvRun - Run command using specific ruby version.